### PR TITLE
Expose a method to run an arbitrary function in our Angular context.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -150,32 +150,48 @@ function makeJsonFriendlyRoute(injector, route) {
     return defer.promise;
 }
 
-function middlewareWithAngular(func, serverScripts, prepContext) {
-
-    return function (request, response, next) {
+function makeRunInContext(serverScripts, prepContext) {
+    return function (func) {
         var context = angularcontext.Context();
         context.runFiles(
             serverScripts,
             function (success, error) {
                 if (error) {
-                    sendError(error, response);
                     context.dispose();
-                    return;
+                    func(undefined, error);
                 }
 
                 ngoverrides.registerModule(context);
                 prepContext(
                     context,
                     function () {
-                        try {
-                            func(request, response, next, context);
-                        }
-                        catch (err) {
-                            context.dispose();
-                            sendError(err, response);
-                        }
+                        func(context);
                     }
                 );
+            }
+        );
+    };
+}
+
+function middlewareWithAngular(func, serverScripts, prepContext) {
+
+    return function (request, response, next) {
+        var runInContext = makeRunInContext(serverScripts, prepContext);
+        runInContext(
+            function (context, error) {
+                if (error) {
+                    sendError(error, response);
+                    context.dispose();
+                    return;
+                }
+
+                try {
+                    func(request, response, next, context);
+                }
+                catch (err) {
+                    context.dispose();
+                    sendError(err, response);
+                }
             }
         );
     };
@@ -391,7 +407,8 @@ function makeInstance(options) {
         sdrApi: makeSdrApi(serverScripts, prepContext, angularModules),
         wrapMiddlewareWithAngular: function (func) {
             return middlewareWithAngular(func, serverScripts, prepContext);
-        }
+        },
+        runInContext: makeRunInContext(serverScripts, prepContext)
     };
 
 }

--- a/tests/run_in_context.js
+++ b/tests/run_in_context.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var path = require('path');
+
+exports.testRunInContext = function (test) {
+    test.expect(7);
+    var angularServer = require('../lib/main.js');
+
+    var server = angularServer.Server(
+        {
+            serverScripts: [
+                path.join(__dirname, '../res/fakeangular.js')
+            ]
+        }
+    );
+
+    test.ok(server, 'server is truthy');
+    test.ok(server.runInContext, 'server.runInContext is truthy');
+
+    server.runInContext(
+        function (context, error) {
+            test.ok(error === undefined, 'error is undefined');
+            test.ok(context, 'context is truthy');
+
+            var angular = context.getAngular();
+
+            test.ok(angular, 'angular is truthy');
+            test.ok(angular.fake, 'angular is fake');
+
+            test.ok(
+                angular.modulesRegistered.indexOf('angularjs-server') !== -1,
+                'angularjs-server module registered'
+            );
+
+            test.done();
+        }
+    );
+
+};


### PR DESCRIPTION
This is intended to allow callers to use the context to do things other
than serve requests. For example, a caller could use this during startup
to inspect something in the application and pre-generate certain responses,
or conditionally register middlewares in Express, or other such tasks.

This then becomes a building block for the existing middlewareWithAngular
function, that provides the same capability for the common case where
it's a middleware that needs the context.
