### PR TITLE
Forcefully abort pending HTTP requests when disposing.

### DIFF
--- a/lib/ngoverrides.js
+++ b/lib/ngoverrides.js
@@ -151,6 +151,8 @@ function registerModule(context) {
                 $get: function ($location) {
                     var openReqs = 0;
                     var doneCallbacks = [];
+                    var nextRequestId = 0;
+                    var pendingRequests = {};
 
                     var startRequest = function () {
                         openReqs++;
@@ -166,6 +168,18 @@ function registerModule(context) {
                             }
                         }
                     };
+
+                    // Register so we can know when our context is being disposed, so that we
+                    // can abort any outstanding requests.
+                    context.onDispose(
+                        function () {
+                            for (var requestId in pendingRequests) {
+                                var req = pendingRequests[requestId];
+                                req.abort();
+                                delete pendingRequests[requestId];
+                            }
+                        }
+                    );
 
                     var ret = function (
                         reqMethod, reqUrl, reqData, callback, headers,
@@ -214,7 +228,9 @@ function registerModule(context) {
                                 return;
                             }
 
-                            var req = module.request(
+                            var thisRequestId = nextRequestId;
+                            nextRequestId++;
+                            var req = pendingRequests[thisRequestId] = module.request(
                                 {
                                     hostname: urlParts.hostname,
                                     port: urlParts.port,
@@ -226,6 +242,11 @@ function registerModule(context) {
                                     }
                                 },
                                 function (res) {
+                                    // ignore responses to aborted requests
+                                    if (! pendingRequests[thisRequestId]) {
+                                        return;
+                                    }
+
                                     var status = res.statusCode;
                                     // Angular's interface expects headers as a string,
                                     // so we have to do a bit of an abstraction inversion here.
@@ -238,12 +259,21 @@ function registerModule(context) {
                                     res.on(
                                         'data',
                                         function (chunk) {
+                                            // ignore responses to aborted requests
+                                            if (! pendingRequests[thisRequestId]) {
+                                                return;
+                                            }
                                             resData.push(chunk);
                                         }
                                     );
                                     res.on(
                                         'end',
                                         function () {
+                                            // ignore responses to aborted requests
+                                            if (! pendingRequests[thisRequestId]) {
+                                                return;
+                                            }
+                                            delete pendingRequests[thisRequestId];
                                             callback(status, resData.join(''), headers);
                                             endRequest();
                                         }
@@ -253,6 +283,11 @@ function registerModule(context) {
                             req.on(
                                 'error',
                                 function (err) {
+                                    // ignore responses to aborted requests
+                                    if (! pendingRequests[thisRequestId]) {
+                                        return;
+                                    }
+                                    delete pendingRequests[thisRequestId];
                                     // FIXME: What is a good error response code for this case?
                                     callback(-1, undefined, undefined);
                                     endRequest();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "lint": "jshint -c .jshintrc lib/* tests/*"
     },
     "dependencies": {
-        "angularcontext": "~0.0.8",
+        "angularcontext": "~0.0.10",
         "escape-html": "1.0.0",
         "express": "~3.4.4"
     },


### PR DESCRIPTION
Our server code (should!) always call context.dispose() at the end of a
request to reclaim the resources used by the context. However, if that
happens when an HTTP request is outstanding, it's important that we
intercept that and prevent any calls back into callbacks that live inside
the context, since those callbacks can end up trying to make use of
objects that are no longer available, which can in turn cause nodejs to
crash.
