### PR TITLE
Simplify the interface for building Angular-aware middlewares.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,14 +18,18 @@ function sendError(error, response) {
     );
 }
 
-function getInjector(context, modules, request) {
+function getInjector(context, modules, template) {
     modules = context.getAngular().copy(modules);
     modules.unshift('angularjs-server');
 
-    var injector = context.injector(modules);
+    var element = context.element(template);
+    modules.push(
+        function ($provide) {
+            $provide.value('$rootElement', element);
+        }
+    );
 
-    var reqContext = injector.get('serverRequestContext');
-    reqContext.setRequest(request);
+    var injector = context.injector(modules);
 
     return injector;
 }
@@ -150,7 +154,7 @@ function makeJsonFriendlyRoute(injector, route) {
     return defer.promise;
 }
 
-function makeRunInContext(serverScripts, prepContext) {
+function makeRunInContext(serverScripts, angularModules, prepContext, template) {
     return function (func) {
         var context = angularcontext.Context();
         context.runFiles(
@@ -165,7 +169,20 @@ function makeRunInContext(serverScripts, prepContext) {
                 prepContext(
                     context,
                     function () {
-                        func(context);
+
+                        var $injector = getInjector(context, angularModules, template);
+
+                        // Although the called module will primarily use the injector, we
+                        // also give it indirect access to the angular object so it can
+                        // make use of Angular's "global" functions.
+                        $injector.angular = context.getAngular();
+
+                        // The caller must call this when it's finished in order to free the context.
+                        $injector.close = function () {
+                            context.dispose();
+                        };
+
+                        func($injector);
                     }
                 );
             }
@@ -173,25 +190,31 @@ function makeRunInContext(serverScripts, prepContext) {
     };
 }
 
-function middlewareWithAngular(func, serverScripts, prepContext) {
+function middlewareWithAngular(func, serverScripts, angularModules, prepContext, template) {
+
+    var runInContext = makeRunInContext(serverScripts, angularModules, prepContext, template);
 
     return function (request, response, next) {
-        var runInContext = makeRunInContext(serverScripts, prepContext);
         runInContext(
-            function (context, error) {
+            function ($injector, error) {
                 if (error) {
                     sendError(error, response);
-                    context.dispose();
                     return;
                 }
 
-                try {
-                    func(request, response, next, context);
-                }
-                catch (err) {
-                    context.dispose();
-                    sendError(err, response);
-                }
+                // Tell the context about our current request, so $location will work.
+                var reqContext = $injector.get('serverRequestContext');
+                reqContext.setRequest(request);
+
+                // Override the end() method so that we can automatically dispose the
+                // context when the request ends.
+                var previousEnd = response.end;
+                response.end = function () {
+                    previousEnd.apply(this, arguments);
+                    $injector.close();
+                };
+
+                func(request, response, next, $injector);
             }
         );
     };
@@ -223,20 +246,12 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
     var hideShim = '<script>document.write("<script type=\'dummy/x-hide-document\'>")</script>';
 
     return middlewareWithAngular(
-        function (request, response, next, context) {
-            modules = context.getAngular().copy(modules);
-            var element = context.element(template);
-            modules.push(
-                function ($provide) {
-                    $provide.value('$rootElement', element);
-                }
-            );
-            var injector = getInjector(context, modules, request);
-
+        function (request, response, next, injector) {
             var $compile = injector.get('$compile');
             var $rootScope = injector.get('$rootScope');
             var $httpBackend = injector.get('$httpBackend');
             var $route = injector.get('$route');
+            var element = injector.get('$rootElement');
 
             var link = $compile(element);
             link($rootScope);
@@ -274,7 +289,6 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
                         catch (e) {
                             response.writeHead(500);
                             response.end('Route data could not be rendered as JSON');
-                            context.dispose();
                             return;
                         }
 
@@ -305,7 +319,7 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
                             function () {
                                 $rootScope.$digest();
 
-                                var container = context.element('<div></div>');
+                                var container = injector.angular.element('<div></div>');
                                 container.append(element);
 
                                 // We remove all scripts from the snapshot, because the snapshot
@@ -318,11 +332,9 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
                                 container = null;
 
                                 response.end(hideShim + staticSnapshot);
-                                context.dispose();
                             },
                             function (error) {
                                 sendError(error, response);
-                                context.dispose();
                             }
                         );
                     }
@@ -335,6 +347,7 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
             }
         },
         serverScripts,
+        modules,
         prepContext
     );
 
@@ -343,9 +356,7 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
 function makeSdrApi(serverScripts, prepContext, modules) {
 
     return middlewareWithAngular(
-        function (request, response, next, context) {
-            var injector = getInjector(context, modules, request);
-
+        function (request, response, next, injector) {
             var reqContext = injector.get('serverRequestContext');
             var path = reqContext.location.path();
             var search = reqContext.location.search();
@@ -368,28 +379,25 @@ function makeSdrApi(serverScripts, prepContext, modules) {
                         catch (e) {
                             response.writeHead(500);
                             response.end('Route data could not be rendered as JSON');
-                            context.dispose();
                             return;
                         }
 
                         response.writeHead(200);
                         response.end(jsonRet);
-                        context.dispose();
                     },
                     function (error) {
                         response.writeHead(200);
                         response.end('{}');
-                        context.dispose();
                     }
                 );
             }
             else {
                 response.writeHead(200);
                 response.end('{}');
-                context.dispose();
             }
         },
         serverScripts,
+        modules,
         prepContext
     );
 
@@ -400,15 +408,15 @@ function makeInstance(options) {
     var serverScripts = options.serverScripts;
     var prepContext = options.prepContext || function (context, callback) { callback(); };
     var clientScripts = options.clientScripts || [];
-    var angularModules = options.angularModules;
+    var angularModules = options.angularModules || [];
 
     return {
         htmlGenerator: makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, angularModules),
         sdrApi: makeSdrApi(serverScripts, prepContext, angularModules),
         wrapMiddlewareWithAngular: function (func) {
-            return middlewareWithAngular(func, serverScripts, prepContext);
+            return middlewareWithAngular(func, serverScripts, angularModules, prepContext, template);
         },
-        runInContext: makeRunInContext(serverScripts, prepContext)
+        runInContext: makeRunInContext(serverScripts, angularModules, prepContext, template)
     };
 
 }

--- a/res/fakeangular.js
+++ b/res/fakeangular.js
@@ -1,9 +1,11 @@
 
 // This is a fake angular-like thing that we can load into an angular context for tests.
 var modulesRegistered = [];
+var requestsRegistered = [];
 window.angular = {
     fake: true,
     modulesRegistered: modulesRegistered,
+    requestsRegistered: requestsRegistered,
     module: function (name, deps) {
         if (deps) {
             modulesRegistered.push(name);
@@ -20,5 +22,36 @@ window.angular = {
                 return this;
             }
         };
+    },
+    injector: function (modules) {
+        var fakeInjector = {};
+        fakeInjector.get = function (name) {
+            if (name === 'serverRequestContext') {
+                return {
+                    setRequest: function (request) {
+                        requestsRegistered.push(request);
+                    }
+                };
+            }
+            else {
+                return {
+                    fake: true
+                };
+            }
+        };
+        return fakeInjector;
+    },
+    copy: function (thing) {
+        // this is only here to make getInjector work in our server module, so it only supports shallow
+        // copies of arrays since that's all we need for this situation.
+        var ret = [];
+        for (var i = 0; i < thing.length; i++) {
+            ret.push(thing[i]);
+        }
+        return ret;
+    },
+    element: function () {
+        // just enough element-ness to keep the tests happy
+        return [];
     }
 };

--- a/tests/run_in_context.js
+++ b/tests/run_in_context.js
@@ -18,11 +18,11 @@ exports.testRunInContext = function (test) {
     test.ok(server.runInContext, 'server.runInContext is truthy');
 
     server.runInContext(
-        function (context, error) {
+        function ($injector, error) {
             test.ok(error === undefined, 'error is undefined');
-            test.ok(context, 'context is truthy');
+            test.ok($injector, '$injector is truthy');
 
-            var angular = context.getAngular();
+            var angular = $injector.angular;
 
             test.ok(angular, 'angular is truthy');
             test.ok(angular.fake, 'angular is fake');

--- a/tests/wrap_middleware.js
+++ b/tests/wrap_middleware.js
@@ -3,7 +3,7 @@
 var path = require('path');
 
 exports.testWrapMiddleware = function (test) {
-    test.expect(9);
+    test.expect(11);
     var angularServer = require('../lib/main.js');
 
     var server = angularServer.Server(
@@ -22,19 +22,28 @@ exports.testWrapMiddleware = function (test) {
     var expectedNext = {};
 
     var mw = server.wrapMiddlewareWithAngular(
-        function (gotReq, gotRes, gotNext, gotContext) {
+        function (gotReq, gotRes, gotNext, gotInjector) {
             test.ok(gotReq === expectedReq, 'request passed through');
             test.ok(gotRes === expectedRes, 'response passed through');
             test.ok(gotNext === expectedNext, 'next passed through');
-            test.ok(gotContext, 'context is truthy');
+            test.ok(gotInjector, 'injector is truthy');
 
-            var angular = gotContext.getAngular();
+            var angular = gotInjector.angular;
 
             test.ok(angular, 'angular is truthy');
             test.ok(angular.fake, 'angular is fake');
             test.ok(
                 angular.modulesRegistered.indexOf('angularjs-server') !== -1,
                 'angularjs-server module registered'
+            );
+
+            test.ok(
+                angular.requestsRegistered.length === 1,
+                'nodejs request was registered exactly once'
+            );
+            test.ok(
+                angular.requestsRegistered[0] === expectedReq,
+                'the registered request is what we expected'
             );
 
             test.done();


### PR DESCRIPTION
After getting some experience with writing middlewares that make use of this module, we learned that every middleware ends up creating an injector, setting the request on it, and then disposing the context at the end.

This is a breaking change to switch to a more convenient interface where the middleware receives an injector directly, and the context is automatically disposed when the response ends. This means that in the common case a middleware function has less boilerplate and can concentrate on whatever unique logic it's providing. The main 'angular' object is still available via an extension property $injector.angular.

After this change, a wrapped middleware has this signature:

``` js
function someMiddleware(request, response, next, $injector) {
    ...
    response.end(...); // automatically disposes the AngularJS context
}
```
