### PR TITLE
Enable redirects that happen in a request context

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -211,6 +211,14 @@ function middlewareWithAngular(func, serverScripts, angularModules, prepContext,
                 // context when the request ends.
                 var previousEnd = response.end;
                 response.end = function () {
+                    if (!response.headersSent && reqContext.getRedirectTo()) {
+                        response.writeHead(301, {
+                            'Content-Type': 'text/html; charset=utf-8',
+                            // cache for a small period of time (30 seconds as the API endpoints)
+                            'Cache-Control': 'max-age=30',
+                            'Location': reqContext.getRedirectTo()
+                        });
+                    }
                     previousEnd.apply(this, arguments);
                     $injector.close();
                 };


### PR DESCRIPTION
Not 100% sure this is the right spot for this but it works for me. It would be better if we could have a way to pass the status code of the redirect (301 or 302) but based on the source (window.location.path change) this might not make sense.
