### PR TITLE
Enhance the overriden $location service's search() method.

### DIFF
--- a/lib/ngoverrides.js
+++ b/lib/ngoverrides.js
@@ -103,12 +103,12 @@ function registerModule(context) {
                 };
             };
             var parsedUrl = function (code) {
-                return function (set) {
+                return function (set, value) {
                     if (request) {
                         if (! requestUrlParts) {
                             requestUrlParts = url.parse(request.url, true);
                         }
-                        return code(requestUrlParts, set);
+                        return code(requestUrlParts, set, value);
                     }
                     else {
                         throw new Error('location not available yet');
@@ -170,7 +170,19 @@ function registerModule(context) {
                         }
                     ),
                     search: parsedUrl(
-                        function (parts) {
+                        function (parts, set, paramValue) {
+                            if (set) {
+                                if (paramValue === null) {
+                                    delete parts.query[paramValue];
+                                }
+                                else if (paramValue) {
+                                    parts.query[set] = paramValue;
+                                }
+                                else {
+                                    parts.query = set;
+                                }
+                                return this;
+                            }
                             return parts.query;
                         }
                     ),


### PR DESCRIPTION
We had only implemented search() as a getter. This change emulates Angular's
behavior for using this method as a setter as well, allowing an application
running in server context to manipulate the request's query string.
