### PR TITLE
Upgrading Angular to 1.3.8 and adding a fix

### DIFF
--- a/examples/weather/template.html
+++ b/examples/weather/template.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<base href="/">
 <title>AngularJS-Server Weather Example</title>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 <link rel="stylesheet" type="text/css" href="/:static/style.css">

--- a/lib/main.js
+++ b/lib/main.js
@@ -140,6 +140,15 @@ function makeHtmlGenerator(serverScripts, prepContext, clientScripts, template, 
             var path = reqContext.location.path();
             var search = reqContext.location.search();
 
+            //Fixing trailing slash issue - when navigating from home to any city (ex: boston) and reload the page, somehow '\' is added to the end of location.href, which breaks the routing.
+            //This code will remove the trailing slash
+            //Taken from https://github.com/angular-ui/ui-router/issues/50#issuecomment-64895625
+            var re = /(.+)(\/+)(\?.*)?$/
+            if(re.test(path)) {
+              path = path.replace(re, '$1$3')
+            }
+            //End of fix
+            
             var matchedRoute = $route.getByPath(path, search);
 
             if (matchedRoute) {


### PR DESCRIPTION
#1 - upgraded to angular 1.3.8 version
#2 - tested with express version 4.10.7
#3 - Added a fix for trailing slash during page reload