### PR TITLE
Mimic the behavior of UrlResolve

### DIFF
--- a/lib/ngoverrides.js
+++ b/lib/ngoverrides.js
@@ -586,7 +586,16 @@ function registerModule(context) {
                     }
 
                     var baseUrl = serverRequestContext.location.absUrl();
-                    var normalizedVal = url.resolve(baseUrl, uri);
+
+                    // mimic the behavior of UrlResolve
+                    var normalizedVal;
+                    if (uri === null) {
+                        normalizedVal = url.resolve(baseUrl, '/null');
+                    }
+                    else {
+                        normalizedVal = url.resolve(baseUrl, uri);
+                    }
+
                     if (normalizedVal !== '' && !normalizedVal.match(regex)) {
                         return 'unsafe:' + normalizedVal;
                     }


### PR DESCRIPTION
Angular UrlResovle that is using the DOM to parse the URL has a certain behavior to handle the value null.
It results in the URI '/null'

Mimic that behavior here instead of dying with:

TypeError: Parameter 'url' must be a string, not object
    at Url.parse (url.js:118:11)
    at urlParse (url.js:112:5)
    at Url.resolve (url.js:406:29)
    at Object.urlResolve [as resolve] (url.js:402:40)
    at sanitizeUri (/Users/aimbert/devel/phoenix/node_modules/angularjs-server/lib/ngoverrides.js:589:45)