### PR TITLE
Preserve request headers in our overridden $httpBackend.

### DIFF
--- a/lib/ngoverrides.js
+++ b/lib/ngoverrides.js
@@ -439,6 +439,9 @@ function registerModule(context) {
 
                         var thisRequestId = nextRequestId;
                         nextRequestId++;
+                        // Pass through any headers that were set in the original request
+                        headers = headers || {};
+                        headers.Host = urlParts.host;
                         var req = pendingRequests[thisRequestId] = module.request(
                             {
                                 hostname: urlParts.hostname,
@@ -446,9 +449,7 @@ function registerModule(context) {
                                 path: urlParts.pathname +
                                     (urlParts.search ? urlParts.search : ''),
                                 method: reqMethod,
-                                headers: {
-                                    'Host': urlParts.host
-                                }
+                                headers: headers
                             },
                             function (res) {
                                 // ignore responses to aborted requests


### PR DESCRIPTION
This allows "client"-side $http requests to send headers that will be seen by the server-side middleware. The use case was for doing Basic auth, but it seems generally useful.